### PR TITLE
Type name validator

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -19,6 +19,13 @@ const DROP_ATTRIBUTE_MARKER = Symbol('A marker to drop the attributes');
 
 const referencePrefix = '#/definitions/';
 function getItemTypeName (typeName, buildingInputType) {
+  // If any type-name references an external file or URI, normalize the type name to be valid GraphQL
+  if (typeName.endsWith('.json') || typeName.endsWith('.json/') || typeName.startsWith('http')) {
+    const removedExtension = typeName.replace('.json', '').replace('schema', '');
+    const normalizedTypeName = uppercamelcase(removedExtension.slice(removedExtension.lastIndexOf('/') + 1, removedExtension.length));
+    return `${normalizedTypeName}${buildingInputType ? INPUT_SUFFIX : ''}`;
+  }
+
   return uppercamelcase(`${typeName}${buildingInputType ? INPUT_SUFFIX : ''}`);
 }
 function getReferenceName (referenceName, buildingInputType) {
@@ -139,7 +146,9 @@ function mapType (context, attributeDefinition, attributeName, buildingInputType
       if (context.types.get(typeReferenceName) instanceof GraphQLUnionType && buildingInputType) {
         return DROP_ATTRIBUTE_MARKER;
       }
-      throw new UnknownTypeReference(`The referenced type ${typeReferenceName} (${buildingInputType}) is unknown in ${attributeName}`);
+      const err = new UnknownTypeReference(`The referenced type ${typeReferenceName} (${buildingInputType || 'Not Input Type'}) is unknown in ${attributeName}`);
+      if (typeReferenceName.startsWith('http')) err.subMessage = 'Cannot reference schema from external URIs. Duplicate the schema in a local file';
+      throw err;
     }
     return referencedType;
   }

--- a/src/converter.js
+++ b/src/converter.js
@@ -20,14 +20,19 @@ const DROP_ATTRIBUTE_MARKER = Symbol('A marker to drop the attributes');
 const referencePrefix = '#/definitions/';
 
 function normalizeTypeName (typeName) {
-  const removedExtension = typeName.replace('.json', '').replace('schema', '');
-  const normalizedTypeName = uppercamelcase(removedExtension.slice(removedExtension.lastIndexOf('/') + 1, removedExtension.length));
+  /* If the typeName is a URI, this will extract the
+     file-name between the last '/' and '.json' extension
+     If the typeName is not a URI, this will only camelCase it */
+  const normalizedTypeName = uppercamelcase(
+    typeName
+      .slice(typeName.lastIndexOf('/') + 1, typeName.length)
+      .replace(/(\.schema)?\.json/g, '')
+  );
   validators.validateTypeName(typeName, normalizedTypeName);
   return normalizedTypeName;
 }
 
 function getItemTypeName (typeName, buildingInputType) {
-  // If any type-name references an external file or URI, normalize the type name to be valid GraphQL
   const normalizedTypeName = normalizeTypeName(typeName);
   return `${normalizedTypeName}${buildingInputType ? INPUT_SUFFIX : ''}`;
 }

--- a/src/converter.js
+++ b/src/converter.js
@@ -18,16 +18,20 @@ const DEFINITION_PREFIX = 'Definition';
 const DROP_ATTRIBUTE_MARKER = Symbol('A marker to drop the attributes');
 
 const referencePrefix = '#/definitions/';
+
+function normalizeTypeName (typeName) {
+  const removedExtension = typeName.replace('.json', '').replace('schema', '');
+  const normalizedTypeName = uppercamelcase(removedExtension.slice(removedExtension.lastIndexOf('/') + 1, removedExtension.length));
+  validators.validateTypeName(typeName, normalizedTypeName);
+  return normalizedTypeName;
+}
+
 function getItemTypeName (typeName, buildingInputType) {
   // If any type-name references an external file or URI, normalize the type name to be valid GraphQL
-  if (typeName.endsWith('.json') || typeName.endsWith('.json/') || typeName.startsWith('http')) {
-    const removedExtension = typeName.replace('.json', '').replace('schema', '');
-    const normalizedTypeName = uppercamelcase(removedExtension.slice(removedExtension.lastIndexOf('/') + 1, removedExtension.length));
-    return `${normalizedTypeName}${buildingInputType ? INPUT_SUFFIX : ''}`;
-  }
-
-  return uppercamelcase(`${typeName}${buildingInputType ? INPUT_SUFFIX : ''}`);
+  const normalizedTypeName = normalizeTypeName(typeName);
+  return `${normalizedTypeName}${buildingInputType ? INPUT_SUFFIX : ''}`;
 }
+
 function getReferenceName (referenceName, buildingInputType) {
   return referenceName.startsWith(referencePrefix)
     ? getItemTypeName(`${DEFINITION_PREFIX}.${referenceName.split(referencePrefix)[1]}`, buildingInputType)
@@ -277,5 +281,6 @@ module.exports = {
   UnknownTypeReference,
   newContext,
   convert,
-  getConvertEnumFromGraphQLCode
+  getConvertEnumFromGraphQLCode,
+  normalizeTypeName
 };

--- a/src/error-handling.js
+++ b/src/error-handling.js
@@ -4,6 +4,7 @@ const fs = require('fs-extra');
 // Directory-name must exist, and Directory-name must point to valid directory
 async function validatePathName (dir) {
   try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     const files = await fs.readdir(dir);
     return files;
   } catch (err) {
@@ -28,6 +29,7 @@ async function validateJSONSyntax (file, dir) {
   }
 
   try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     const fileContent = await fs.readFile(path.join(dir, file));
     const parsedFileContent = JSON.parse(fileContent);
     if (Array.isArray(parsedFileContent)) {
@@ -72,6 +74,7 @@ function validateTypeName (typeName, normalizedTypeName) {
 // If there are definitions, each definition must have a type defined
 function validateDefinitions (definitions) {
   for (const key in definitions) {
+    // eslint-disable-next-line security/detect-object-injection
     if (!definitions[key].type) {
       const err = new Error(`Each key in definitions must have a declared type`);
       err.subLocation = `Definition for "${key}" schema`;

--- a/src/error-handling.js
+++ b/src/error-handling.js
@@ -61,6 +61,14 @@ function validateTopLevelId (typeName, schema) {
   }
 }
 
+function validateTypeName (typeName, normalizedTypeName) {
+  if (!/^[_a-zA-Z][_a-zA-Z0-9]*$/.test(normalizedTypeName)) {
+    const err = new Error(`The id of ${typeName} does not convert into a valid GraphQL type name`);
+    err.subMessage = `The ID or .json file-name must match the regular expression /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ${normalizedTypeName} does not`;
+    throw err;
+  }
+}
+
 // If there are definitions, each definition must have a type defined
 function validateDefinitions (definitions) {
   for (const key in definitions) {
@@ -76,5 +84,6 @@ module.exports = {
   validatePathName,
   validateJSONSyntax,
   validateTopLevelId,
+  validateTypeName,
   validateDefinitions
 };

--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,7 @@ function jsonSchemasToGraphqlSchema (schemas, withMutations = true) {
       const result = {};
       for (const [name, type] of context.inputs.entries()) {
         // We must normalize the name here, to match the normalized type names of each schema
-        let normalizedName = normalizeTypeName(name);
-        if (normalizedName.endsWith('In')) normalizedName = normalizedName.slice(0, normalizedName.lastIndexOf('In'));
+        const normalizedName = normalizeTypeName(name);
 
         // It's ok to ignore the object injection attack here because
         // the object being edited does not contain any private data to be

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 const { GraphQLSchema, GraphQLObjectType, GraphQLString } = require('graphql');
-const uppercamelcase = require('uppercamelcase');
 
 const { newContext, convert, UnknownTypeReference, normalizeTypeName } = require('./converter');
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const { GraphQLSchema, GraphQLObjectType, GraphQLString } = require('graphql');
 const uppercamelcase = require('uppercamelcase');
 
-const { newContext, convert, UnknownTypeReference } = require('./converter');
+const { newContext, convert, UnknownTypeReference, normalizeTypeName } = require('./converter');
 
 function convertSchemas (context, schemas) {
   const referencedUnknownType = [];
@@ -61,8 +61,7 @@ function jsonSchemasToGraphqlSchema (schemas, withMutations = true) {
       const result = {};
       for (const [name, type] of context.inputs.entries()) {
         // We must normalize the name here, to match the normalized type names of each schema
-        const removedExtension = name.replace('.json', '').replace('schema', '');
-        let normalizedName = uppercamelcase(removedExtension.slice(removedExtension.lastIndexOf('/') + 1, removedExtension.length));
+        let normalizedName = normalizeTypeName(name);
         if (normalizedName.endsWith('In')) normalizedName = normalizedName.slice(0, normalizedName.lastIndexOf('In'));
 
         // It's ok to ignore the object injection attack here because

--- a/test/converter.js
+++ b/test/converter.js
@@ -328,6 +328,25 @@ test('Unknown $ref attribute type', async function (test) {
   await test.throws(schema, UnknownTypeReference);
 });
 
+test('Unknown $ref attribute type from external URI', async function (test) {
+  const simpleType = {
+    id: 'Ref',
+    type: 'object',
+    properties: {
+      attribute: {
+        $ref: 'http://UnknownType.schema.json'
+      }
+    }
+  };
+
+  const expectedType = `type Ref {
+    attribute: UnknownType
+  }`;
+
+  const schema = testConversion(test, simpleType, 'Ref', expectedType);
+  await test.throws(schema, UnknownTypeReference);
+});
+
 test('Known $ref attribute type', async function (test) {
   const otherType = {
     id: 'OtherType',

--- a/test/dummy-data/pass2.json
+++ b/test/dummy-data/pass2.json
@@ -1,9 +1,0 @@
-{
-  "$id": "http://some-external-uri.schema.json",
-  "type": "object",
-  "properties": {
-    "attribute": {
-      "type": "string"
-    }
-  }
-}

--- a/test/dummy-data/pass2.json
+++ b/test/dummy-data/pass2.json
@@ -1,0 +1,9 @@
+{
+  "$id": "http://some-external-uri.schema.json",
+  "type": "object",
+  "properties": {
+    "attribute": {
+      "type": "string"
+    }
+  }
+}

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -1,4 +1,5 @@
 const { test } = require('ava');
+
 const validators = require('../src/error-handling');
 const dummyData = require('./dummy-data/pass.json');
 
@@ -128,6 +129,29 @@ test('throws error if top-level type is not object', function (test) {
     test.is(err.subLocation, `JSON file starting with ${JSON.stringify(badSchema).substring(0, 25)}...`);
   }
 });
+
+test('throws error if a normalized type name is not a valid GraphQL type name', function (test) {
+  const badTypeName = 'boo(k';
+  const normalizedBadTypeName = 'Boo(k';
+  try {
+    validators.validateTypeName(badTypeName, normalizedBadTypeName);
+    test.fail('Should throw error');
+  } catch (err) {
+    test.is(err.message, `The id of ${badTypeName} does not convert into a valid GraphQL type name`);
+    test.is(err.subMessage, `The ID or .json file-name must match the regular expression /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ${normalizedBadTypeName} does not`);
+  }
+});
+
+// test.only('throws error if id cannot be converted into valid GraphQL type name', function (test) {
+//   const badId = 'boo(k';
+//   try {
+//     normalizeTypeName(badId);
+//     test.fail('Should throw error');
+//   } catch (err) {
+//     test.is(err.message, `The id of ${badId} does not convert into a valid GraphQL type name`);
+//     test.is(err.subMessage, 'The ID or .json file-name must match the regular expression /^[_a-zA-Z][_a-zA-Z0-9]*$/ but Boo(k does not');
+//   }
+// });
 
 test('throws error if definitions have no type defined', function (test) {
   const badSchema = {

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -142,17 +142,6 @@ test('throws error if a normalized type name is not a valid GraphQL type name', 
   }
 });
 
-// test.only('throws error if id cannot be converted into valid GraphQL type name', function (test) {
-//   const badId = 'boo(k';
-//   try {
-//     normalizeTypeName(badId);
-//     test.fail('Should throw error');
-//   } catch (err) {
-//     test.is(err.message, `The id of ${badId} does not convert into a valid GraphQL type name`);
-//     test.is(err.subMessage, 'The ID or .json file-name must match the regular expression /^[_a-zA-Z][_a-zA-Z0-9]*$/ but Boo(k does not');
-//   }
-// });
-
 test('throws error if definitions have no type defined', function (test) {
   const badSchema = {
     id: 'badSchema',


### PR DESCRIPTION
This PR adds a normalizing function for the GraphQL type names.  For example, an `$id` or `$ref` that points to `https://example.com/geographical-location.schema.json` will convert into the GraphQL type name of `GeographicalLocation`.  
If the normalized type name turns out to be an invalid GraphQL type name, a descriptive error will throw.
Closes #21 