### PR TITLE
Array of schema

### DIFF
--- a/bin/convert-json-schemas-to-graphql-types.js
+++ b/bin/convert-json-schemas-to-graphql-types.js
@@ -13,7 +13,11 @@ async function convertDir (dir, asJs) {
 
   for (const file of files) {
     const schemaContents = await validators.validateJSONSyntax(file, dir); // If valid, will return parsed JSON-schema from file
-    schemas.push(schemaContents);
+    if (Array.isArray(schemaContents)) {
+      schemaContents.forEach(oneSchema => schemas.push(oneSchema));
+    } else {
+      schemas.push(schemaContents);
+    }
   }
 
   const schema = jsonSchemasToGraphqlSchema(schemas);

--- a/test/dummy-data/fail-1.json
+++ b/test/dummy-data/fail-1.json
@@ -7,5 +7,6 @@
         "type": "string"
       }
     }
-  }
+  },
+  null
 ]

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -56,25 +56,23 @@ test('throws error if files are not all .json', async function (test) {
   }
 });
 
-test('throws error if file contains an array of schema', async function (test) {
+test('throws error if .json file is an Array containing an invalid schema', async function (test) {
   const file = 'fail-1.json';
   const directory = './test/dummy-data';
   try {
     await validators.validateJSONSyntax(file, directory);
     test.fail('Should throw error');
   } catch (err) {
-    test.is(err.message, `Each file must include only one json-schema, not an array of schema`);
-    test.is(err.subMessage, `Failed to convert file '${file}'. It should not be an array.`);
-    test.is(err.subLocation, `./test/dummy-data/${file}`);
+    test.is(err.message, 'Each entry in the JSON array must be an object type');
+    test.is(err.subMessage, `Check element with index 1 in file ${file}`);
   }
 
   try {
     await validators.validateJSONSyntax(file, `${directory}/`);
     test.fail('Should throw error');
   } catch (err) {
-    test.is(err.message, `Each file must include only one json-schema, not an array of schema`);
-    test.is(err.subMessage, `Failed to convert file '${file}'. It should not be an array.`);
-    test.is(err.subLocation, `./test/dummy-data/${file}`);
+    test.is(err.message, 'Each entry in the JSON array must be an object type');
+    test.is(err.subMessage, `Check element with index 1 in file ${file}`);
   }
 });
 

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -108,7 +108,7 @@ test('throws error if typeName is not defined', function (test) {
     test.fail('Should throw error');
   } catch (err) {
     test.is(err.message, `JSON-Schema must have a key 'id' or '$id' to identify the top-level schema`);
-    test.is(err.subLocation, `JSON file starting with ${JSON.stringify(badSchema).substring(0, 25)}...`);
+    test.is(err.subLocation, `JSON schema starting with ${JSON.stringify(badSchema).substring(0, 25)}...`);
   }
 });
 
@@ -124,7 +124,7 @@ test('throws error if top-level type is not object', function (test) {
     test.fail('Should throw error');
   } catch (err) {
     test.is(err.message, `Top-level type must be 'object', not '${badSchema.type}'`);
-    test.is(err.subLocation, `JSON file starting with ${JSON.stringify(badSchema).substring(0, 25)}...`);
+    test.is(err.subLocation, `JSON schema starting with ${JSON.stringify(badSchema).substring(0, 25)}...`);
   }
 });
 


### PR DESCRIPTION
This PR allows the _.json_ files to contain an array of json-schema instead of just a single schema.  A specific error will throw if each entry in the array is not a valid json-schema. Closes #20 